### PR TITLE
Refresh titles after mapping

### DIFF
--- a/src/Mapper/JsonPointer.php
+++ b/src/Mapper/JsonPointer.php
@@ -117,10 +117,15 @@ class JsonPointer implements MapperInterface
             $itemValues->add($value);
         }
 
+        // Update resource titles
         $titlePropertyDql = "SELECT p FROM Omeka\Entity\Property p JOIN p.vocabulary v WHERE p.localName = 'title' AND v.prefix = 'dcterms'";
         $titleProperty = $this->entityManager->createQuery($titlePropertyDql)->getOneOrNullResult();
         $titleHydrator = new ResourceTitleHydrator;
-        $titleHydrator->hydrate($mediaEntity, $titleProperty);
-        $titleHydrator->hydrate($itemEntity, $titleProperty);
+        if ($valuesToAdd['media']) {
+            $titleHydrator->hydrate($mediaEntity, $titleProperty);
+        }
+        if ($valuesToAdd['item']) {
+            $titleHydrator->hydrate($itemEntity, $titleProperty);
+        }
     }
 }

--- a/src/Mapper/JsonPointer.php
+++ b/src/Mapper/JsonPointer.php
@@ -2,6 +2,7 @@
 namespace ExtractMetadata\Mapper;
 
 use Doctrine\Common\Collections\Criteria;
+use Omeka\Api\Adapter\ResourceTitleHydrator;
 use Omeka\Entity;
 use Rs\Json\Pointer;
 
@@ -115,5 +116,11 @@ class JsonPointer implements MapperInterface
         foreach ($valuesToAdd['item'] as $value) {
             $itemValues->add($value);
         }
+
+        $titlePropertyDql = "SELECT p FROM Omeka\Entity\Property p JOIN p.vocabulary v WHERE p.localName = 'title' AND v.prefix = 'dcterms'";
+        $titleProperty = $this->entityManager->createQuery($titlePropertyDql)->getOneOrNullResult();
+        $titleHydrator = new ResourceTitleHydrator;
+        $titleHydrator->hydrate($mediaEntity, $titleProperty);
+        $titleHydrator->hydrate($itemEntity, $titleProperty);
     }
 }


### PR DESCRIPTION
Mapping extracted metadata to a resource's title property doesn't update the separately-saved title column for the resource.

This change fixes that issue by running the ResourceTitleHydrator for the affected item and media at the end of the mapping step, updating the title in the same way that saving through the API does.